### PR TITLE
:bug: fix attribute name for verifyAndFix declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export type ISSMLCheckError =
 
 export interface ISSMLCheckVerifyResponse {
   errors?: ISSMLCheckError[];
-  ssml?: string;
+  fixedSSML?: string;
 }
 
 export function check(


### PR DESCRIPTION
Hi @gsdriver  @armonge thanks for your great work,
Your documentation correctly says that the verifyAndFix method is returning an object with the property "fixedSSML". But your type declaration calls it "ssml". Typescript projects will throw an compile error.
Greetings André